### PR TITLE
[Feature] Added Property for default enabling text-feature via config

### DIFF
--- a/src/components/search_params/main.ts
+++ b/src/components/search_params/main.ts
@@ -682,6 +682,7 @@ export class UrlSearchParamUpdate {
                     color: string | null | undefined;
                     html_class: string | null | undefined;
                     css_class: string | null | undefined;
+                    default: boolean | null | undefined;
                     hide: {
                       hidden: boolean;
                       class: string;
@@ -830,31 +831,56 @@ export class UrlSearchParamUpdate {
         let hide = paramCheck(variants[v].hide, false);
 
         if (urlParam.get(opt) === null) {
-          // urlParam.set(opt, "off");
-          let selected = removeMarkup(
-            html_class,
-            css_class,
-            color,
-            hide,
-            style
-          );
-
-          try {
-            let slider = document.getElementById(opt_slider) as HTMLElement;
-            slider.classList.remove(color);
-            slider.removeAttribute("data");
-            slider.classList.remove("slider-number");
-          } catch (err) {
-            console.log(`slider class ${opt_slider} not found!`);
-          }
-
-          if (
-            (document.getElementById(opt) as HTMLInputElement).checked === true
-          ) {
-            (document.getElementById(opt) as HTMLInputElement).checked = false;
-            (document.getElementById(opt) as HTMLInputElement).classList.remove(
-              active
+          if(variants[v].default === true) { // if default is true
+            count_active += 1;
+            let selected = addMarkup(html_class, css_class, color, hide, style);
+            try {
+              let slider = document.getElementById(opt_slider) as HTMLElement;
+              slider.setAttribute("data", selected);
+              count += parseInt(selected);
+              slider.classList.add("slider-number");
+              slider.classList.add(color);
+              urlParam.set(opt, "on");
+            } catch (err) {
+              console.log(`slider class ${opt_slider} not found!`);
+            }
+  
+            if (
+              (document.getElementById(opt) as HTMLInputElement).checked === false
+            ) {
+              (document.getElementById(opt) as HTMLInputElement).checked = true;
+              (document.getElementById(opt) as HTMLInputElement).classList.add(
+                active
+              );
+            }
+  
+          } else {
+            // urlParam.set(opt, "off");
+            let selected = removeMarkup(
+              html_class,
+              css_class,
+              color,
+              hide,
+              style
             );
+
+            try {
+              let slider = document.getElementById(opt_slider) as HTMLElement;
+              slider.classList.remove(color);
+              slider.removeAttribute("data");
+              slider.classList.remove("slider-number");
+            } catch (err) {
+              console.log(`slider class ${opt_slider} not found!`);
+            }
+
+            if (
+              (document.getElementById(opt) as HTMLInputElement).checked === true
+            ) {
+              (document.getElementById(opt) as HTMLInputElement).checked = false;
+              (document.getElementById(opt) as HTMLInputElement).classList.remove(
+                active
+              );
+            }
           }
         } else if (!["on", "off"].includes(urlParam.get(opt))) {
           console.log(
@@ -939,7 +965,7 @@ export class UrlSearchParamUpdate {
 
           /* default value e.g. off should not be added to url */
           urlParam.delete(opt);
-        }
+        } 
 
         let citation_url_str = paramCheck(
           variants[v].chg_citation,

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,7 @@ var editor = new LoadEditor({
         color: "color-feature1",
         html_class: "html-class-feature1",
         css_class: "css-class-feature1",
+        default: true,
         hide: {
           hidden: true,
           class: "html-class-feature15",


### PR DESCRIPTION
Enable text-feature on default, if property is set

Usage:
```js
{
      opt: "prs",
      color: "blue",
      title: "Personen",
      html_class: "persons",
      css_class: "pers",
      default: true,
      hide: {
        hidden: false,
        class: "persons .entity",
      },
      chg_citation: "citation-url",
      features: {
        all: false,
        class: "features-1",
      },
    },
```

`default=true` will enable this feature if no url-parm was found.
Setting this property, will push `[opt]=true` to url parms.